### PR TITLE
Update rabbitmq config with last known version of shovel config

### DIFF
--- a/primary/rabbitmq.config
+++ b/primary/rabbitmq.config
@@ -1,1 +1,33 @@
-[{rabbit, [{loopback_users, []}]}].
+[  
+  {rabbit, [{loopback_users, []}]},
+  {rabbitmq_shovel,
+    [ {shovels, [ {hermesShovel,
+                    [ {sources,
+                        [ {brokers, [ "amqp://127.0.0.1:5672"]}
+                        , {declarations, [ {'exchange.declare',
+                                              [ {exchange, <<"hermesExchange">>}
+                                              , {type, <<"fanout">>}
+                                              ]}
+                                         , {'queue.declare',
+                                              [{arguments,
+                                                 [{<<"x-message-ttl">>, long, 60000}]}]}
+                                         , {'queue.bind',
+                                              [ {exchange, <<"hermesExchange">>}
+                                              , {queue,    <<>>}
+                                              ]}
+                                         ]}
+                        ]}
+                    , {destinations,
+                        [ {broker, "amqp://138.197.206.227:5672"}
+                        , {declarations, [ {'exchange.declare',
+                                              [ {exchange, <<"hermesExchange">>}
+                                              , {type, <<"fanout">>}
+                                              ]}
+                                         ]}
+                        ]}
+                    , {queue, <<>>}
+                    , {reconnect_delay, 5}
+                    ]}
+                ]}
+    ]}
+].


### PR DESCRIPTION
Original one was lost, so we had to restore it.