### PR TITLE
Fix the display ratio of the primary pi

### DIFF
--- a/primary/config.txt
+++ b/primary/config.txt
@@ -1,47 +1,9 @@
-# Set framebuffer depth so both screens have the same depth, and keep Xinerama happy
 framebuffer_depth=16
 
-# uncomment if you get no picture on HDMI for a default "safe" mode
-#hdmi_safe=0
-
-# uncomment this if your display has a black border of unused pixels visible
-# and your display can output without overscan
-#disable_overscan=1
-
-# uncomment the following to adjust overscan. Use positive numbers if console
-# goes off screen, and negative if there is too much border
-#overscan_left=16
-#overscan_right=16
-#overscan_top=16
-#overscan_bottom=16
-
-# uncomment to force a console size. By default it will be display's size minus
-# overscan.
-#framebuffer_width=1280
-#framebuffer_height=720
-
-# uncomment if hdmi display is not detected and composite is being output
-#hdmi_force_hotplug=1
-
-# uncomment to force a specific HDMI mode (here we are forcing 800x480!)
+hdmi_cvt=800 480 60 6
 hdmi_group=2
-hdmi_mode=4
-# hdmi_mode=81
-hdmi_cvt 800 480 60 6 0 0 0
-
-# uncomment to force a HDMI mode rather than DVI. This can make audio work in
-# DMT (computer monitor) modes
-#hdmi_drive=2
-
-# uncomment to increase signal to HDMI, if you have interference, blanking, or
-# no display
-#config_hdmi_boost=4
-
-# uncomment for composite PAL
-#sdtv_mode=2
-
-#uncomment to overclock the arm. 700 MHz is the default.
-#arm_freq=800
+hdmi_mode=87
+hdmi_drive=2
 
 # for more options see http://elinux.org/RPi_config.txt
 gpu_mem=256


### PR DESCRIPTION
We were creating a custom ratio, but not actually using it.
Refs: https://www.raspberrypi.org/documentation/configuration/config-txt/video.md