### PR TITLE
Bill/primarypiupdates

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,6 +16,10 @@ The `config.txt` file should be placed in `/boot/`.
 The `rabbitmq.config` file is needed for communication between the two pis.
 This file is should be placed in `/etc/rabbitmq/`
 
+The `.desktop` files will be run on startup. 
+It will run the startup scripts to run domovoi.
+These files should be placed in `/home/pi/.config/autostart/`
+
 = Instructions to run SetupScript
 
 On the raspberry pi, run raspi-config, and increase the RAM to 512MB.

--- a/primary/Startup.sh
+++ b/primary/Startup.sh
@@ -1,16 +1,8 @@
 #!/bin/bash
-# Note - When using two screens, it acts as two logins, so the .profile is run twice
-# Be careful to not accidentally get it to run domovoi twice. 
-# First, check if Hermes or Dashboard is running
-sleep 6
-start=true
-if pgrep -l "Epsilon" > /dev/null
+if pgrep -l "Schulich" > /dev/null
 then
-	echo "An instance of Hermes or Dashboard is already running."
-	start=false
-fi
-if [ $start = true ];
-then
-	echo "Starting programs"
-	(export DISPLAY=:0 && cd /home/pi/Desktop/Epsilon-Domovoi && sudo -E ./domovoi.py primary)
+    echo "Already Running"
+else
+    export DISPLAY=:0
+    cd /home/pi/Documents/SolarCar/Epsilon-Domovoi && sudo -E ./domovoi.py primary
 fi

--- a/primary/config.txt
+++ b/primary/config.txt
@@ -1,47 +1,9 @@
-# Set framebuffer depth so both screens have the same depth, and keep Xinerama happy
 framebuffer_depth=16
 
-# uncomment if you get no picture on HDMI for a default "safe" mode
-#hdmi_safe=0
-
-# uncomment this if your display has a black border of unused pixels visible
-# and your display can output without overscan
-#disable_overscan=1
-
-# uncomment the following to adjust overscan. Use positive numbers if console
-# goes off screen, and negative if there is too much border
-#overscan_left=16
-#overscan_right=16
-#overscan_top=16
-#overscan_bottom=16
-
-# uncomment to force a console size. By default it will be display's size minus
-# overscan.
-#framebuffer_width=1280
-#framebuffer_height=720
-
-# uncomment if hdmi display is not detected and composite is being output
-#hdmi_force_hotplug=1
-
-# uncomment to force a specific HDMI mode (here we are forcing 800x480!)
+hdmi_cvt=800 480 60 6
 hdmi_group=2
-hdmi_mode=4
-# hdmi_mode=81
-hdmi_cvt 800 480 60 6 0 0 0
-
-# uncomment to force a HDMI mode rather than DVI. This can make audio work in
-# DMT (computer monitor) modes
-#hdmi_drive=2
-
-# uncomment to increase signal to HDMI, if you have interference, blanking, or
-# no display
-#config_hdmi_boost=4
-
-# uncomment for composite PAL
-#sdtv_mode=2
-
-#uncomment to overclock the arm. 700 MHz is the default.
-#arm_freq=800
+hdmi_mode=87
+hdmi_drive=2
 
 # for more options see http://elinux.org/RPi_config.txt
 gpu_mem=256

--- a/primary/domovoi.desktop
+++ b/primary/domovoi.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Type=Application
+Name=Startup
+Exec=/home/pi/Documents/SolarCar/Epsilon-Raspberry/Startup.sh

--- a/secondary/Startup.sh
+++ b/secondary/Startup.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 if pgrep -l "Epsilon" > /dev/null
 then
-	echo "Programs are already running"
+	echo "running"
 else
-	sleep 5
-	echo "Starting Programs"
-	(cd /home/pi/Desktop/Epsilon-Domovoi && sudo ./domovoi.py secondary)
+	echo "Starting"
+	(cd /home/pi/Documents/SolarCar/Epsilon-Domovoi && sudo -E ./domovoi.py secondary)
 fi

--- a/secondary/domovoi.desktop
+++ b/secondary/domovoi.desktop
@@ -1,0 +1,4 @@
+[Desktop Entry]
+Type=Application
+Name=Startup
+Exec=/home/pi/Documents/SolarCar/Epsilon-Raspberry/secondary/Startup.sh


### PR DESCRIPTION
- Fixed the display ratio of the primary pi
- Changed the way that Startup.sh was run from `.profile` to autostart.

See commit messages for more details.