### PR TITLE
SFT-166 Remove references to domovoi and use systemd services

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,6 +20,16 @@ The `.desktop` files will be run on startup.
 It will run the startup scripts to run domovoi.
 These files should be placed in `/home/pi/.config/autostart/`
 
+The `.service` files will be run on startup.
+To activate, place these files in `/home/pi/.config/systemd/user/`, then run:
+
+```
+    systemctl --user daemon-reload
+    systemctl --user enable <service-name>
+```
+Where `<service-name>` is the name of the service you want to add.
+Make sure the programs run by the service can be found.
+
 = Setting Up Cross Compilation
 
 See the https://github.com/UCSolarCarTeam/Epsilon-Raspberry/blob/master/cross-compile/README.adoc[cross compilation setup guide] for instructions on how to setup cross compilation.

--- a/primary/StartBackupCamera.sh
+++ b/primary/StartBackupCamera.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+COMMAND="/opt/SchulichBackupCamera/BackupCamera"
+ARGS="10 0 800 480 1024 768"
+
+SECONDARYPI_ADDRESS="google.com"
+
+ping -q -c1 $SECONDARYPI_ADDRESS > /dev/null
+
+if [ $? -ne 0 ]; then
+	echo "Cannot reach other pi"
+	($COMMAND $ARGS)
+fi
+

--- a/primary/StartDashboard.sh
+++ b/primary/StartDashboard.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+COMMAND="/opt/SchulichEpsilonDashboard/EpsilonDashboard"
+ARGS="--platform xcb"
+
+SECONDARYPI_ADDRESS="google.com"
+
+ping -q -c1 $SECONDARYPI_ADDRESS > /dev/null
+
+if [ $? -ne 0 ]; then
+	echo "Cannot reach other pi"
+	ARGS="-r --platform xcb"
+fi
+
+($COMMAND $ARGS)

--- a/primary/Startup.sh
+++ b/primary/Startup.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-if pgrep -l "Schulich" > /dev/null
-then
-    echo "Already Running"
-else
-    export DISPLAY=:0
-    cd /home/pi/Documents/SolarCar/Epsilon-Domovoi && sudo -E ./domovoi.py primary
-fi

--- a/primary/domovoi.desktop
+++ b/primary/domovoi.desktop
@@ -1,4 +1,0 @@
-[Desktop Entry]
-Type=Application
-Name=Startup
-Exec=/home/pi/Documents/SolarCar/Epsilon-Raspberry/Startup.sh

--- a/primary/domovoi/display.txt
+++ b/primary/domovoi/display.txt
@@ -1,2 +1,0 @@
-/opt/SchulichEpsilonHermes/SchulichEpsilonHermes
-/opt/SchulichEpsilonDashboard/EpsilonDashboard -platform xcb

--- a/primary/domovoi/race.txt
+++ b/primary/domovoi/race.txt
@@ -1,3 +1,0 @@
-/opt/SchulichEpsilonHermes/SchulichEpsilonHermes
-/opt/SchulichEpsilonDashboard/EpsilonDashboard -r
-/opt/SchulichBackupCamera/BackupCamera 100 100 100 100 1024 768

--- a/primary/systemd/backup-camera.service
+++ b/primary/systemd/backup-camera.service
@@ -1,0 +1,10 @@
+ [Unit]
+ Description=Start Dashboard
+ After=graphical.target
+
+ [Service]
+ Type=idle
+ ExecStart=/opt/SchulichBackupCamera/StartBackupCamera.sh
+
+ [Install]
+ WantedBy=default.target

--- a/primary/systemd/dashboard.service
+++ b/primary/systemd/dashboard.service
@@ -1,0 +1,10 @@
+ [Unit]
+ Description=Start Dashboard
+ After=graphical.target
+
+ [Service]
+ Type=idle
+ ExecStart=/opt/SchulichEpsilonDashboard/StartDashboard.sh
+
+ [Install]
+ WantedBy=default.target

--- a/primary/systemd/hermes.service
+++ b/primary/systemd/hermes.service
@@ -1,0 +1,10 @@
+ [Unit]
+ Description=Start Hermes
+ After=graphical.target
+
+ [Service]
+ Type=idle
+ ExecStart=/opt/SchulichEpsilonHermes/SchulichEpsilonHermes
+
+ [Install]
+ WantedBy=default.target

--- a/secondary/Startup.sh
+++ b/secondary/Startup.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-if pgrep -l "Epsilon" > /dev/null
-then
-	echo "running"
-else
-	echo "Starting"
-	(cd /home/pi/Documents/SolarCar/Epsilon-Domovoi && sudo -E ./domovoi.py secondary)
-fi

--- a/secondary/domovoi.desktop
+++ b/secondary/domovoi.desktop
@@ -1,4 +1,0 @@
-[Desktop Entry]
-Type=Application
-Name=Startup
-Exec=/home/pi/Documents/SolarCar/Epsilon-Raspberry/secondary/Startup.sh

--- a/secondary/domovoi/display.txt
+++ b/secondary/domovoi/display.txt
@@ -1,3 +1,0 @@
-/home/pi/Desktop/Epsilon-Dashboard/build/EpsilonDashboard -d -platform xcb
-/home/pi/Desktop/BackupCamera/BackupCamera 0 0 683 384 1024 768
-/home/pi/Desktop/Epsilon-Onboard-Media-Control/build/OnboardMediaControl -platform xcb

--- a/secondary/systemd/backup-camera.service
+++ b/secondary/systemd/backup-camera.service
@@ -1,0 +1,10 @@
+ [Unit]
+ Description=Start Dashboard
+ After=graphical.target
+
+ [Service]
+ Type=idle
+ ExecStart=/opt/SchulichBackupCamera/BackupCamera 0 0 800 480 1024 768
+
+ [Install]
+ WantedBy=default.target

--- a/secondary/systemd/dashboard.service
+++ b/secondary/systemd/dashboard.service
@@ -1,0 +1,10 @@
+ [Unit]
+ Description=Start Dashboard
+ After=graphical.target
+
+ [Service]
+ Type=idle
+ ExecStart=/opt/SchulichEpsilonDashboard/EpsilonDashboard -d --platform xcb
+
+ [Install]
+ WantedBy=default.target

--- a/secondary/systemd/onboard-media.service
+++ b/secondary/systemd/onboard-media.service
@@ -1,0 +1,10 @@
+ [Unit]
+ Description=Start Onboard Media Player
+ After=graphical.target
+
+ [Service]
+ Type=idle
+ ExecStart=/opt/SchulichOnboardMediaPlayer/OnboardMediaControl
+
+ [Install]
+ WantedBy=default.target


### PR DESCRIPTION
Systemd services are more robust than .desktop programs, and allow us to add units better and speed up startup. Try to avoid using domovoi and instead handle the pinging of the other pi via a bash script.

I need to test the `StartDashboard.sh` script to see if it actually works on start up, but I need another pi to be the secondary one.